### PR TITLE
Switch default to JDK8

### DIFF
--- a/resources/default_pipeline_environment.yml
+++ b/resources/default_pipeline_environment.yml
@@ -5,7 +5,7 @@ general:
 #Steps Specific Configuration
 steps:
   executeMaven:
-    dockerImage: 'maven:3.5-jdk-7-alpine'
+    dockerImage: 'maven:3.5-jdk-8-alpine'
 
   executeNpm:
     dockerImage: 's4sdk/docker-node-chromium'


### PR DESCRIPTION
Enables state of the art Java projects to compile without pipeline config customizations.