### PR TITLE
Ui5 lint language level

### DIFF
--- a/resources/check-ui5-best-practices/run-ui5-lint.js
+++ b/resources/check-ui5-best-practices/run-ui5-lint.js
@@ -6,7 +6,7 @@ const xmlValidator = require("@sap/di.code-validation.xml")
 const coreValidator = require("@sap/di.code-validation.core")
 const ValidationMetadata = coreValidator.validationMetadata
 
-if (process.argv.length != 3) {
+if (process.argv.length < 3) {
     throw "Expected one argument with path to Component.js file.\nUsage: node check-ui5-best-practices.js my/path/to/Component.js\n"
 }
 
@@ -14,6 +14,20 @@ const componentJs = process.argv[2]
 
 if (!componentJs.toLowerCase().endsWith("component.js")) {
     throw "Argument must be a path to a Component.js file\n"
+}
+
+if (process.argv.length === 4) {
+    const esLanguageLevel = process.argv[3];
+
+    console.log(`[INFO] Setting ES language level to ${esLanguageLevel}.`);
+
+    const basicDefaultConfig = require('./node_modules/@sap/di.code-validation.js/src/defaultConfig/basicDefaultConfig/.eslintrc.json');
+    basicDefaultConfig['env'][esLanguageLevel] = true;
+    fs.writeFileSync('./node_modules/@sap/di.code-validation.js/src/defaultConfig/basicDefaultConfig/.eslintrc.json', JSON.stringify(basicDefaultConfig));
+
+    const fioriCustomRules = require('./node_modules/@sap/di.code-validation.js/src/defaultConfig/fioriCustomRules/.eslintrc.json');
+    fioriCustomRules['env'][esLanguageLevel] = true;
+    fs.writeFileSync('./node_modules/@sap/di.code-validation.js/src/defaultConfig/fioriCustomRules/.eslintrc.json', JSON.stringify(fioriCustomRules));
 }
 
 const projectPath = path.dirname(componentJs)

--- a/resources/check-ui5-best-practices/run-ui5-lint.js
+++ b/resources/check-ui5-best-practices/run-ui5-lint.js
@@ -1,16 +1,16 @@
-const fs = require('fs')
-const path = require('path')
+const fs = require('fs');
+const path = require('path');
 
-const jsValidator = require("@sap/di.code-validation.js")
-const xmlValidator = require("@sap/di.code-validation.xml")
-const coreValidator = require("@sap/di.code-validation.core")
-const ValidationMetadata = coreValidator.validationMetadata
+const jsValidator = require("@sap/di.code-validation.js");
+const xmlValidator = require("@sap/di.code-validation.xml");
+const coreValidator = require("@sap/di.code-validation.core");
+const ValidationMetadata = coreValidator.validationMetadata;
 
 if (process.argv.length < 3) {
     throw "Expected one argument with path to Component.js file.\nUsage: node check-ui5-best-practices.js my/path/to/Component.js\n"
 }
 
-const componentJs = process.argv[2]
+const componentJs = process.argv[2];
 
 if (!componentJs.toLowerCase().endsWith("component.js")) {
     throw "Argument must be a path to a Component.js file\n"
@@ -30,35 +30,35 @@ if (process.argv.length === 4) {
     fs.writeFileSync('./node_modules/@sap/di.code-validation.js/src/defaultConfig/fioriCustomRules/.eslintrc.json', JSON.stringify(fioriCustomRules));
 }
 
-const projectPath = path.dirname(componentJs)
-const validationMetadata = new ValidationMetadata(projectPath)
+const projectPath = path.dirname(componentJs);
+const validationMetadata = new ValidationMetadata(projectPath);
 
-const jsResults = jsValidator.validateFiles(validationMetadata).issues
-const xmlResults = xmlValidator.validateFiles(validationMetadata).issues
+const jsResults = jsValidator.validateFiles(validationMetadata).issues;
+const xmlResults = xmlValidator.validateFiles(validationMetadata).issues;
 
-const mergedResults = jsResults.concat(xmlResults)
+const mergedResults = jsResults.concat(xmlResults);
 
 // Use a set to get rid of duplicate entries
-const setOfFiles = [...new Set(mergedResults.map(issue => issue.path).sort())]
+const setOfFiles = [...new Set(mergedResults.map(issue => issue.path).sort())];
 
-let checkstyleString = '<?xml version="1.0" encoding="UTF-8"?>\n<checkstyle version="8.16">\n'
+let checkstyleString = '<?xml version="1.0" encoding="UTF-8"?>\n<checkstyle version="8.16">\n';
 setOfFiles.forEach(file => {
     checkstyleString += fileXmlBlock(file)
-})
-checkstyleString += '</checkstyle>\n'
+});
+checkstyleString += '</checkstyle>\n';
 
-const resultFileName = projectPath.replace(/\//g, '_').replace(/\s+/g, '_')
-fs.writeFileSync(resultFileName + ".ui5lint.xml", checkstyleString)
+const resultFileName = projectPath.replace(/\//g, '_').replace(/\s+/g, '_');
+fs.writeFileSync(resultFileName + ".ui5lint.xml", checkstyleString);
 
-fs.writeFileSync(resultFileName + ".ui5lint.json", JSON.stringify({ "issues": mergedResults }, null, 4))
+fs.writeFileSync(resultFileName + ".ui5lint.json", JSON.stringify({ "issues": mergedResults }, null, 4));
 
 function fileXmlBlock(file) {
-    let result = `  <file name="${escapeXml(file)}">\n`
-    const findingIsInCurrentFile = it => it.path === file
+    let result = `  <file name="${escapeXml(file)}">\n`;
+    const findingIsInCurrentFile = it => it.path === file;
     mergedResults.filter(findingIsInCurrentFile).forEach(finding => {
         result += findingXmlLine(finding)
-    })
-    result += '  </file>\n'
+    });
+    result += '  </file>\n';
     return result
 }
 


### PR DESCRIPTION
## Context

If applied, this commit will implement a functionality that you can set the es language level for the ui5 lint script.

## Definition of Done
Please consider all items.

- [ ] I carefully reviewed my own pull request before assigning someone.
- [ ] Changes to the configuration are also documented in the [configuration.md](https://github.com/SAP/cloud-s4-sdk-pipeline/blob/master/configuration.md)
- [ ] This change is operations-relevant and I have updated the operations guide correspondingly
- [ ] There are tests covering this change

## Merging
Please use squash merge and provide a good commit message, e.g. inspired by the context above. 
Make sure to remove the reference to this pull request and that this template is not part of the commit message.
Also, please ensure the commit message is not just a list of "WIP" commit messages.
